### PR TITLE
Standardized Description When Rendering Issues List

### DIFF
--- a/client/src/components/IssueCard.jsx
+++ b/client/src/components/IssueCard.jsx
@@ -15,6 +15,16 @@ import {
 } from "@/components/ui/tooltip"
 
 const IssueCard = ({ issue = mockIssue }) => {
+  function standardizeIssueDescriptionLength(issueDescription){
+    const descriptionCharacterLimit = 47;
+    let shortenedDescription = "";
+
+    for(let i = 0; i < descriptionCharacterLimit; i++){
+      shortenedDescription += issueDescription[i]
+    }
+
+    return shortenedDescription + "...";
+  }
   return (
     <Link to={`/issues/${issue.id}`}>
       <Card className={`hover:border-primary/50 transition-all hover:shadow-md cursor-pointer ${issue.status === 'CLOSED' ? 'opacity-70' : ''}`}>
@@ -22,7 +32,7 @@ const IssueCard = ({ issue = mockIssue }) => {
           <div className="flex items-start justify-between gap-4">
             <div className="flex-1 min-w-0">
               <h3 className="font-semibold text-lg mb-1 truncate">{issue.title}</h3>
-              <p className="text-sm text-muted-foreground line-clamp-2">{issue.description}</p>
+              <p className="text-sm text-muted-foreground line-clamp-2">{standardizeIssueDescriptionLength(issue.description)}</p>
             </div>
             <div className="flex flex-col gap-2 items-end shrink-0">
               <StatusBadge status={issue.status} />


### PR DESCRIPTION
### Bug
Before, a description was displayed in its entirety when rendering the `description` of an issue. Some issues would have more or less text, ultimately resulting in odd spacing and unexpected UI display of tickets. 

After, upon rendering an issue card, before the card is rendered, the issue's `description` string is sent to a helper function: `standardizeIssueDescriptionLength()`. This function finds a limit that we decide to display instead of the entire description. Ultimately, normalizing the length of the issue card itself. The description itself remains unaffected and can be viewed fully in the issue details page after clicking a particular issue.

### Before Picture
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/2c2c4d18-55a8-481d-968e-d3747f1ab33f" />

### After Picture
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/5b5c4e8e-00f3-4d97-904c-0ba6b6458f5e" />
