### PR TITLE
Fixes issue card width when description is shorter than prescribed limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,10 @@ Thumbs.db
 
 # Docker
 *.log
+
+# Rooflow Integration files
+.roo/
+.roomodes
+*.py
+*.sh
+plans/

--- a/client/src/components/IssueCard.jsx
+++ b/client/src/components/IssueCard.jsx
@@ -19,6 +19,9 @@ const IssueCard = ({ issue = mockIssue }) => {
     const descriptionCharacterLimit = 47;
     let shortenedDescription = "";
 
+    if(issueDescription.length < descriptionCharacterLimit) {
+      return issueDescription
+    }
     for(let i = 0; i < descriptionCharacterLimit; i++){
       shortenedDescription += issueDescription[i]
     }
@@ -27,7 +30,7 @@ const IssueCard = ({ issue = mockIssue }) => {
   }
   return (
     <Link to={`/issues/${issue.id}`}>
-      <Card className={`hover:border-primary/50 transition-all hover:shadow-md cursor-pointer ${issue.status === 'CLOSED' ? 'opacity-70' : ''}`}>
+      <Card className={`min-w-[24rem] hover:border-primary/50 transition-all hover:shadow-md cursor-pointer ${issue.status === 'CLOSED' ? 'opacity-70' : ''}`}>
         <CardHeader className="pb-3">
           <div className="flex items-start justify-between gap-4">
             <div className="flex-1 min-w-0">


### PR DESCRIPTION
### Before
Originally, was set to fix description characters limit when descriptions were lengthy. However, I did not take into account when descriptions were shorter than the prescribed limit. This resulted in strings of 'undefined' being written as the iteration up until the set limit was met. 

### After
Now, there is a check to see if the description of an issue is shorter than the prescribed limit. If it is, it is simply returned. This, however, also resulted in a variance of issue card width. There is now a new property on the `<Card />` component that defines a hard minimum width limit that every card ought to have, 24 rem or (24 * 16 pixels) for each card's width